### PR TITLE
Provide import button with viewname instead of URL

### DIFF
--- a/netbox_plugin_extensions/templates/netbox_plugin_extensions/generic/object_list.html
+++ b/netbox_plugin_extensions/templates/netbox_plugin_extensions/generic/object_list.html
@@ -14,7 +14,7 @@
           {% plugin_add_button content_type.model_class %}
       {% endif %}
       {% if permissions.add and 'import' in action_buttons %}
-          {% plugin_import_button content_type.model_class %}
+          {% plugin_import_button content_type.model_class|plugin_validated_viewname:"import" %}
       {% endif %}
       {% if 'export' in action_buttons %}
           {% plugin_export_button content_type %}

--- a/netbox_plugin_extensions/templatetags/plugin_buttons.py
+++ b/netbox_plugin_extensions/templatetags/plugin_buttons.py
@@ -61,9 +61,7 @@ def plugin_add_button(instance):
 
 
 @register.inclusion_tag('buttons/import.html')
-def plugin_import_button(instance):
-    viewname = _get_plugin_viewname(instance, 'import')
-    url = reverse(viewname)
+def plugin_import_button(url):
 
     return {
         'import_url': url,


### PR DESCRIPTION
The `buttons/import.html` template feeds the `import_url` through the `url` filter. This commit adapts to that (odd) behaviour.